### PR TITLE
Fix for FLUME-625

### DIFF
--- a/flume-core/src/main/java/com/cloudera/flume/conf/FlumeConfiguration.java
+++ b/flume-core/src/main/java/com/cloudera/flume/conf/FlumeConfiguration.java
@@ -949,7 +949,7 @@ public class FlumeConfiguration extends Configuration {
   }
 
   public String getPluginClasses() {
-    return get(PLUGIN_CLASSES, "");
+    return get(PLUGIN_CLASSES, "").replaceAll("\\s+", "");
   }
 
   public String getHiveHost() {

--- a/flume-core/src/main/java/com/cloudera/flume/core/EventImpl.java
+++ b/flume-core/src/main/java/com/cloudera/flume/core/EventImpl.java
@@ -94,7 +94,8 @@ public class EventImpl extends EventBaseImpl {
       String host, Map<String, byte[]> fields) {
     super(fields);
     Preconditions.checkNotNull(s);
-    Preconditions.checkArgument(s.length <= MAX_BODY_SIZE);
+    final long bodySize = s.length;
+    Preconditions.checkArgument(bodySize <= MAX_BODY_SIZE, "The given body with a size of %s bytes exceeds the maximum body size of %s bytes",bodySize,MAX_BODY_SIZE);
     // this string construction took ~5% of exec time!
     // , "byte length is " + s.length + " which is not < " + MAX_BODY_SIZE);
     Preconditions.checkNotNull(pri);

--- a/flume-core/src/main/java/com/cloudera/flume/core/EventImpl.java
+++ b/flume-core/src/main/java/com/cloudera/flume/core/EventImpl.java
@@ -94,8 +94,7 @@ public class EventImpl extends EventBaseImpl {
       String host, Map<String, byte[]> fields) {
     super(fields);
     Preconditions.checkNotNull(s);
-    final long bodySize = s.length;
-    Preconditions.checkArgument(bodySize <= MAX_BODY_SIZE, "The given body with a size of %s bytes exceeds the maximum body size of %s bytes",bodySize,MAX_BODY_SIZE);
+    Preconditions.checkArgument(s.length <= MAX_BODY_SIZE);
     // this string construction took ~5% of exec time!
     // , "byte length is " + s.length + " which is not < " + MAX_BODY_SIZE);
     Preconditions.checkNotNull(pri);

--- a/flume-core/src/test/java/com/cloudera/flume/conf/TestFlumeConfiguration.java
+++ b/flume-core/src/test/java/com/cloudera/flume/conf/TestFlumeConfiguration.java
@@ -31,6 +31,38 @@ public class TestFlumeConfiguration {
       super(true);
     }
   }
+  
+  @Test
+  public void testPluginClassesWithWhiteSpaceAtBeginning() {
+	  FlumeConfiguration cfg = new TestableConfiguration();
+	  cfg.set(FlumeConfiguration.PLUGIN_CLASSES, " \n a.b.c,d.e.f");
+	  
+	  assertEquals("White spaces at the beginning must be stripped", "a.b.c,d.e.f", cfg.getPluginClasses());
+  }
+  
+  @Test
+  public void testPluginClassesWithWhiteSpaceAtEnd() {
+	  FlumeConfiguration cfg = new TestableConfiguration();
+	  cfg.set(FlumeConfiguration.PLUGIN_CLASSES, "a.b.c,d.e.f \n ");
+	  
+	  assertEquals("White spaces at the end must be stripped", "a.b.c,d.e.f", cfg.getPluginClasses());
+  }
+  
+  @Test
+  public void testPluginClassesWithWhiteSpaceInTheMiddle() {
+	  FlumeConfiguration cfg = new TestableConfiguration();
+	  cfg.set(FlumeConfiguration.PLUGIN_CLASSES, "a.b.c,\nd.e.f,   g.h.i");
+	  
+	  assertEquals("White spaces in the middle must be stripped", "a.b.c,d.e.f,g.h.i", cfg.getPluginClasses());
+  }
+  
+  @Test
+  public void testPluginClassesWithWhiteSpace() {
+	  FlumeConfiguration cfg = new TestableConfiguration();
+	  cfg.set(FlumeConfiguration.PLUGIN_CLASSES, " \n a.b.c,\nd.e.f,   g.h.i \n ");
+	  
+	  assertEquals("White spaces must be stripped", "a.b.c,d.e.f,g.h.i", cfg.getPluginClasses());
+  }
 
   @Test
   public void testParseGossipServers() {


### PR DESCRIPTION
when loading classes after defining plugins within flume-site.xml
(e.g. line breaks at the beginning or end of the <value> tag, after
auto-formatting)
