### PR TITLE
Maven cleanup - adding relativePath to all POMs

### DIFF
--- a/flume-config-web/pom.xml
+++ b/flume-config-web/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flume-config-web</artifactId>

--- a/flume-core/pom.xml
+++ b/flume-core/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>Flume Core</name>

--- a/flume-distribution/pom.xml
+++ b/flume-distribution/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flume-distribution</artifactId>

--- a/flume-docs/pom.xml
+++ b/flume-docs/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>Flume Docs</name>

--- a/flume-log4j-appender/pom.xml
+++ b/flume-log4j-appender/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flume-log4j-appender</artifactId>

--- a/flume-microbenchmarks/pom.xml
+++ b/flume-microbenchmarks/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>Flume Microbenchmark tests</name>

--- a/flume-node-web/pom.xml
+++ b/flume-node-web/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>Flume Node Web</name>

--- a/flume-windows-dist/pom.xml
+++ b/flume-windows-dist/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>flume</artifactId>
     <groupId>com.cloudera</groupId>
     <version>0.9.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>com.cloudera</groupId>


### PR DESCRIPTION
Just noticed that not all POMs have <relativePath>s pointing to their parents - there's no reason to not do that, so, well, here it is.
