### PR TITLE
Fix of encoding and failover

### DIFF
--- a/flume-core/src/main/java/com/cloudera/flume/master/availability/FailoverChainSink.java
+++ b/flume-core/src/main/java/com/cloudera/flume/master/availability/FailoverChainSink.java
@@ -56,8 +56,7 @@ public class FailoverChainSink extends EventSink.Base {
   public FailoverChainSink(Context context, String specFormat,
       List<String> list, long initialBackoff, long maxBackoff)
       throws FlumeSpecException {
-    snk = buildSpec(context, specFormat, list, new CappedExponentialBackoff(
-        initialBackoff, maxBackoff));
+    snk = buildSpec(context, specFormat, list, initialBackoff, maxBackoff);
   }
 
   /**
@@ -81,7 +80,7 @@ public class FailoverChainSink extends EventSink.Base {
         cur = tsnk;
         continue;
       }
-      cur = new BackOffFailOverSink(tsnk, cur, policy);
+      cur = new BackOffFailOverSink(tsnk, cur, initialBackoff, maxBackoff);
     }
     return cur;
   }

--- a/flume-core/src/main/java/com/cloudera/util/ByteBufferInputStream.java
+++ b/flume-core/src/main/java/com/cloudera/util/ByteBufferInputStream.java
@@ -37,7 +37,11 @@ public class ByteBufferInputStream extends InputStream {
   @Override
   public int read() throws IOException {
     try {
-      return buf.get();
+      // ORIGINAL
+      //return buf.get();
+    	
+      // To support UTF-8 encoding. Fixed by tyouiifan
+      return buf.get() & 0xFF;
     } catch (BufferUnderflowException e) {
       throw new EOFException();
     }

--- a/flume-core/src/main/java/com/cloudera/util/ByteBufferInputStream.java
+++ b/flume-core/src/main/java/com/cloudera/util/ByteBufferInputStream.java
@@ -37,10 +37,6 @@ public class ByteBufferInputStream extends InputStream {
   @Override
   public int read() throws IOException {
     try {
-      // ORIGINAL
-      //return buf.get();
-    	
-      // To support UTF-8 encoding. Fixed by tyouiifan
       return buf.get() & 0xFF;
     } catch (BufferUnderflowException e) {
       throw new EOFException();


### PR DESCRIPTION
Two fixes 
1. Support UTF-8 encoding (fix of character corruption)
2. Failover will work correctory (reconnect timer will not reset when two flume-nodes down).
