### PR TITLE
fix possible race condition in Cursor

### DIFF
--- a/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
+++ b/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
@@ -318,7 +318,7 @@ public class Cursor {
       if (in.size() == chlen && file.length() == chlen
            && file.lastModified() != lastFileMod) {
         LOG.debug("tail " + file + " : only seen modified timestamp changed, "
-            + "postponing judgement";
+            + "postponing judgement");
         return false;
       }
 

--- a/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
+++ b/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
@@ -314,7 +314,7 @@ public class Cursor {
         return false;
       }
 
-      // d) possable size channged without seen modification timestamp changed
+      // d) possable seen a late timestamp change after size has changed
       if (in.size() == chlen && file.length() == chlen
            && file.lastModified() != lastFileMod) {
         LOG.debug("tail " + file + " : only seen modified timestamp changed, "

--- a/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
+++ b/flume-core/src/main/java/com/cloudera/flume/handlers/text/Cursor.java
@@ -314,6 +314,14 @@ public class Cursor {
         return false;
       }
 
+      // d) possable size channged without seen modification timestamp changed
+      if (in.size() == chlen && file.length() == chlen
+           && file.lastModified() != lastFileMod) {
+        LOG.debug("tail " + file + " : only seen modified timestamp changed, "
+            + "postponing judgement";
+        return false;
+      }
+
       LOG.debug("tail " + file + " : file rotated!");
       resetRAF(); // resetting raf to catch up new file
 


### PR DESCRIPTION
It is possible to seen a late modification timestamp change after file size has changed. 
// host-time  file-size  file-modified-time
//    12:00      50k          12:00
//    12:01      51k          12:00
//    12:02      51k          12:01 <- 
If this happens, and nothing new is written after sleepped 1s in line 293, Cursor will resetRAF and read this file from beginning again !
